### PR TITLE
fixed some typos

### DIFF
--- a/14_Interface/readme.md
+++ b/14_Interface/readme.md
@@ -68,14 +68,14 @@ interface IERC721 is IERC165 {
 ### IERC721事件
 `IERC721`包含3个事件，其中`Transfer`和`Approval`事件在`ERC20`中也有。
 - `Transfer`事件：在转账时被释放，记录代币的发出地址`from`，接收地址`to`和`tokenid`。
-- `Approval`事件：在授权时释放，记录授权地址`owner，被授权地址`approved`和`tokenid`。
+- `Approval`事件：在授权时释放，记录授权地址`owner`，被授权地址`approved`和`tokenid`。
 - `ApprovalForAll`事件：在批量授权时释放，记录批量授权的发出地址`owner`，被授权地址`operator`和授权与否的`approved`。
 
 ### IERC721函数
 - `balanceOf`：返回某地址的NFT持有量`balance`。
 - `ownerOf`：返回某`tokenId`的主人`owner`。
 - `transferFrom`：普通转账，参数为转出地址`from`，接收地址`to`和`tokenId`。
-- `safeTransferFrom`：安全转账（如果接收方是合约地址，会要求实现`ERC721Receiver`接口）。参数为转出地址`from`，接收地址`to`和`tokenId`。
+- `safeTransferFrom`：安全转账（如果接收方是合约地址，会要求实现`ERC721` `Receiver`接口）。参数为转出地址`from`，接收地址`to`和`tokenId`。
 - `approve`：授权另一个地址使用你的NFT。参数为被授权地址`approve`和`tokenId`。
 - `getApproved`：查询`tokenId`被批准给了哪个地址。
 - `setApprovalForAll`：将自己持有的该系列NFT批量授权给某个地址`operator`。


### PR DESCRIPTION
markdown 语法中漏了几个代码块的反引号，导致文本和文本代码之间标注错了。