### PR TITLE
修改继承篇章ReadMe.md

### DIFF
--- a/13_Inheritance/readme.md
+++ b/13_Inheritance/readme.md
@@ -52,11 +52,11 @@ contract Yeye {
 ```solidity
 contract Baba is Yeye{
     // 继承两个function: hip()和pop()，输出改为Baba。
-    function hip() public virtual override{
+    function hip() public pure override{
         emit Log("Baba");
     }
 
-    function pop() public virtual override{
+    function pop() public pure override{
         emit Log("Baba");
     }
 


### PR DESCRIPTION
**virtual** **override** 两个关键字联合起来用是为了下面的多重继承准备的。在简单继承里面，我认为只需要明确 **virtual** 和 **override** 两个关键字的语义即可。
官方文档中也是这么做的。
https://docs.soliditylang.org/en/v0.8.17/contracts.html#inheritance