### PR TITLE
更正了十三讲菱形继承中循环调用的问题

### DIFF
--- a/13_Inheritance/DiamondInheritance.sol
+++ b/13_Inheritance/DiamondInheritance.sol
@@ -24,7 +24,7 @@ contract God {
 contract Adam is God {
     function foo() public virtual override {
         emit Log("Adam.foo called");
-        Adam.foo();
+        God.foo();
     }
 
     function bar() public virtual override {
@@ -36,7 +36,7 @@ contract Adam is God {
 contract Eve is God {
     function foo() public virtual override {
         emit Log("Eve.foo called");
-        Eve.foo();
+        God.foo();
     }
 
     function bar() public virtual override {

--- a/13_Inheritance/readme.md
+++ b/13_Inheritance/readme.md
@@ -189,7 +189,7 @@ contract God {
 contract Adam is God {
     function foo() public virtual override {
         emit Log("Adam.foo called");
-        Adam.foo();
+        God.foo();
     }
 
     function bar() public virtual override {
@@ -201,7 +201,7 @@ contract Adam is God {
 contract Eve is God {
     function foo() public virtual override {
         emit Log("Eve.foo called");
-        Eve.foo();
+        God.foo();
     }
 
     function bar() public virtual override {


### PR DESCRIPTION
更正了readme.md和DiamondInheritance.sol两个文件中的两处错误。
原代码的两个子合约`Adam`和`Eve`在调用父合约的函数`God.foo()`时误写为`Adam.foo()`和`Eve.foo()`，造成了循环引用的错误，已作出更正。